### PR TITLE
R20 deliverytuning

### DIFF
--- a/src/components/Asset/AssetActions/Download.module.css
+++ b/src/components/Asset/AssetActions/Download.module.css
@@ -50,8 +50,8 @@
 }
 
 .copyfeedback {
-  font-size: var(--font-size-mini);
+  font-size: var(--font-size-small);
   color: var(--brand-alert-green);
-  margin-top: -11rem;
+  margin-top: -10rem;
   margin-left: 12rem;
 }

--- a/src/components/Publish/Pricing/SubsPrice.tsx
+++ b/src/components/Publish/Pricing/SubsPrice.tsx
@@ -531,7 +531,7 @@ function EditToolbar(props: EditToolbarProps) {
 
   return (
     <GridToolbarContainer>
-      <Button color="secondary" startIcon={<AddIcon />} onClick={handleClick}>
+      <Button color="primary" startIcon={<AddIcon />} onClick={handleClick}>
         Add subscription row
       </Button>
     </GridToolbarContainer>
@@ -768,7 +768,9 @@ export function SubsPrice() {
           // borderTop: (theme) => `1px solid ${theme.palette.mode === 'light' ? '#f0f0f0' : '#303030'
           //   }`,
         },
-
+        '& .MuiDataGrid-columnHeaderTitle': {
+          font-weight: '800'
+        },
         '& .actions': {
           color: '#F40691'
         },


### PR DESCRIPTION
Changes:
- Made the table headers bold, font-weight:800
- Fixed the color of the “Add Subscription Row” link to be ‘primary’
- Adjusted the margin of the copy feedback of the “COPY FEED URL” button, which was showing up next to the button as opposed to under it. This may or may not be fixed as I can’t test and am just guessing.
